### PR TITLE
Feature/give optimizer params

### DIFF
--- a/hab/train.py
+++ b/hab/train.py
@@ -133,7 +133,7 @@ def main(
     )
     model = selectors.model_selector(model_type)
     criterion = selectors.criterion_selector(loss_type)
-    optimizer = selectors.optimizer_selector(optimizer_type, learn_rate)
+    optimizer = selectors.optimizer_selector(optimizer_type, model, learn_rate)
     train(
         train_dataset,
         valid_dataset,

--- a/hab/utils/selectors.py
+++ b/hab/utils/selectors.py
@@ -1,4 +1,5 @@
 import torch
+from torch.nn import Module
 from typing import Optional
 
 from hab.model.model import HABsModelCNN
@@ -33,19 +34,20 @@ def criterion_selector(loss_type: str) -> torch.nn.Module:
 
 
 def optimizer_selector(
-    optim_type: str, learn_rate: Optional[float] = None
+    optim_type: str, model: Module, learn_rate: Optional[float] = None
 ) -> torch.optim.Optimizer:
     """
     Retrieve specified optimizer object.
 
     :param optim_type: Name of desired optimizer.
+    :param model: Model that contains parameters to be optimized.
     :param learn_rate: Learning rate. If None, torch default value is used.
     :return: Instance of Optimizer object.
     """
     if optim_type == "Adam":
         if learn_rate is not None:
-            return torch.optim.Adam(lr=learn_rate)
+            return torch.optim.Adam(model.parameters(), lr=learn_rate)
         else:
-            return torch.optim.Adam(lr=1e-3)
+            return torch.optim.Adam(model.parameters(), lr=1e-3)
     else:
         raise ValueError(f"Optimizer type must be Adam. Value received: {optim_type}")


### PR DESCRIPTION
This PR gives the Adam optimizer the model parameters that it needs to optimize. 

I did not include them when I originally initiated the optimizer object. Colab threw an error `TypeError: __init__() missing 1 required positional argument: 'params'` when I tried to run my code. These changes should fix this error. 