### PR TITLE
Feature/fix dataset mode

### DIFF
--- a/hab/dataset.py
+++ b/hab/dataset.py
@@ -33,9 +33,9 @@ class HABsDataset(Dataset):
         :param magnitude_increase: Amount to multiple original number of samples by.
         """
         self.data_dir = data_dir
+        self._set_mode(mode)
         self.image_paths = self._get_image_paths()
         self.transform = transform
-        self._set_mode(mode)
         self.magnitude_increase = magnitude_increase
 
     def __len__(self) -> int:


### PR DESCRIPTION
This PR moves the initiation of the HABsDataset `mode` attribute to be before the initiation of the `image_paths` attribute. 

When I ran the program in Colab I was receiving the error `AttributeError: 'HABsDataset' object has no attribute 'mode'`. After looking into it, I realized that `self._get_image_paths()` uses the `mode` attribute, but I created the `mode` attribute after the call to `image_paths`. 