### PR TITLE
Feature/add repr methods

### DIFF
--- a/hab/train.py
+++ b/hab/train.py
@@ -103,7 +103,10 @@ def train(
     logger.info("Saved trained model.")
 
     logger.info("Testing model.")
-    evaluate(model, test_loader)
+    total, correct = evaluate(model, test_loader)
+    logger.info(
+        "Accuracy of the network on the 10 test images: %d %%" % (100 * correct / total)
+    )
 
 
 def main(

--- a/hab/transformations.py
+++ b/hab/transformations.py
@@ -1,41 +1,16 @@
 from PIL import Image
-from typing import Tuple
 
 
-class Rescale(object):
+class CropTimestamp(object):
     """
-    Rescale image to a specified size.
-    """
-
-    # Referenced: https://pytorch.org/tutorials/beginner/data_loading_tutorial.html
-
-    def __init__(self, output_size: Tuple[int, int]):
-        """
-        Construct instance of a Rescale transformation.
-
-        :param output_size: New image size dimensions.
-        """
-        self.output_size = output_size
-
-    def __call__(self, sample: Image) -> Image:
-        """
-        Perform resizing of image.
-
-        :param sample: Image to be rescaled.
-        :return: Rescaled image.
-        """
-        image = sample.resize(self.output_size)
-
-        return image
-
-
-class Crop(object):
-    """
-    Crop image to remove date and time stamp from bottom of image.
+    Crop image to remove date and timestamp from bottom of image.
     """
 
     def __init__(self):
         ...
+
+    def __repr__(self):
+        return self.__class__.__name__
 
     def __call__(self, sample: Image) -> Image:
         """

--- a/hab/utils/training_helper.py
+++ b/hab/utils/training_helper.py
@@ -77,6 +77,8 @@ def evaluate(model: Module, data_loader: DataLoader):
 
     :param model: Model to be evaluated.
     :param data_loader: Data loader that contains the test/validation data.
+    :return total: Total number of images tested.
+    :return correct: Number of test images that were classified correctly.
     """
     correct = 0
     total = 0
@@ -91,6 +93,4 @@ def evaluate(model: Module, data_loader: DataLoader):
             total += targets.size(0)
             correct += (predicted == targets).sum().item()
 
-    logger.info(
-        "Accuracy of the network on the 10 test images: %d %%" % (100 * correct / total)
-    )
+            return total, correct


### PR DESCRIPTION
This PR does the following:

- Creates a `__repr__` method for `CropTimestamp` so this transformation can be printed and represented as a string
- Deletes my custom transform `Rescale` because I realized that is just a wrapper for calling _resize_ on the `PIL Image`. But **torchvison** has a `Resize` transform will do this same functionality. It can take a PIL Image, resize it, and then return a PIL Image. So there was no need for me to redo this work with a custom method.
- Makes `evaluate` method in `training_helper.py` a **pure** function by removing the logging statement (removing global state modification). I moved the logging statement to `train` in `training.py`, which is already a non-pure function. I changed `eval` to return the variables **total** and **correct** and then passed these variable values into the new logging statement in `training.py`