### PR TITLE
Feature/make new log files

### DIFF
--- a/hab/train.py
+++ b/hab/train.py
@@ -7,7 +7,7 @@ from torch.utils.data import DataLoader
 from torchvision import transforms
 
 from hab.dataset import HABsDataset
-from hab.transformations import Rescale, Crop
+from hab.transformations import CropTimestamp
 from hab.utils import habs_logging, selectors
 from hab.utils.training_helper import training_lap, validation_lap, evaluate
 
@@ -60,8 +60,8 @@ def train(
     # TODO - experiment with different combinations of transformations
     data_transform = transforms.Compose(
         [
-            Crop(),
-            Rescale((32, 32)),
+            CropTimestamp(),
+            transforms.RandomCrop((32, 32)),
             transforms.ToTensor(),
             transforms.Normalize(
                 (0.485, 0.456, 0.406), (0.229, 0.224, 0.225)

--- a/hab/utils/habs_logging.py
+++ b/hab/utils/habs_logging.py
@@ -2,8 +2,11 @@ from pathlib import Path
 import logging
 from logging.handlers import RotatingFileHandler
 import sys
+from datetime import datetime
 
-LOGFILE = "/content/gdrive/MyDrive/habs_google/logfile.log"
+now = datetime.now()
+time_suffix = now.strftime("%Y-%m-%d_%H-%M-%S")
+LOGFILE = f"/content/gdrive/MyDrive/habs_google/logfile_{time_suffix}.log"
 Path(LOGFILE).parent.mkdir(parents=True, exist_ok=True)
 
 ch = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
This PR does two things:

1. Adds the current date & time to the name of the log file. This ensures that a new log file with a unique name will be created each time the program runs. Before this change, the logs for a new run would append onto the old log. So it was hard to tell the outputs for the different runs apart from each other. 

2. In the previous PR, I forgot to update the import statements in `train.py` to reflect the changes that were made in `transformations.py`.  These changes are made in this PR. I also replaced the **_Rescale_** call with torchvision's `RandomCrop` transform.