### PR TITLE
Feature/include tensorboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ opencv-contrib-python
 imutils
 torch
 torchvision
+tensorboard
 typer[all]
 pre-commit


### PR DESCRIPTION
This PR incorporates `TensorBoard` into the HABs repo code. TensorBoard was added as a requirement in `requirements.txt`. In `train.py`, an import for `SummaryWriter` was added. Scalar write statements were included for the train loss and val loss in the training loop. 


Now when `! pip install -r  /content/habs/requirements.txt` is called in Colab, TensorBoard will be installed. Locally, TensorBoard was already previously installed in my conda `habs-env` because my `environment.yml` file includes tensorflow, which automatically installs tensorboard. It is still important/necessary to include `TensorBoard` in `requirements.txt` because in the future we might remove the Tensorflow requirement because I think that was necessary for my original implementation that used Keras and I don't think we use it anymore. Also, in Colab, we install all of our dependencies with the requirements file. Therefore, we don't want to rely on only installing TensorBoard through TensorFlow in the environment file. 

Related Issue: #49 