### PR TITLE
Feature/make log folder

### DIFF
--- a/hab/utils/habs_logging.py
+++ b/hab/utils/habs_logging.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 now = datetime.now()
 time_suffix = now.strftime("%Y-%m-%d_%H-%M-%S")
-LOGFILE = f"/content/gdrive/MyDrive/habs_google/logfile_{time_suffix}.log"
+LOGFILE = f"/content/gdrive/MyDrive/habs_google/logs/logfile_{time_suffix}.log"
 Path(LOGFILE).parent.mkdir(parents=True, exist_ok=True)
 
 ch = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
This PR adds a `logs` folder to the directory path for the log files in `habs_logging.py`.

This allows the log files in the `habs_google` directory to be saved in a separate folder. Right now they are being saved in the base folder and it makes everything look cluttered. 

Needed to make a PR for this simple change because right now the directory path for the log files is hard coded in `habs_logging.py` and is not configured.