### PR TITLE
Feature/tensorboard writer

### DIFF
--- a/hab/train.py
+++ b/hab/train.py
@@ -4,7 +4,6 @@ import torch
 from torch.nn import Module
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
-from torch.utils.tensorboard import SummaryWriter
 from torchvision import transforms
 
 from hab.dataset import HABsDataset
@@ -22,6 +21,10 @@ logging.captureWarnings(True)
 logger = logging.getLogger(__name__)
 logger.addHandler(habs_logging.ch)
 logger.addHandler(habs_logging.fh)
+# ---------------------------------
+
+# -------- tensorboard ------------
+writer = habs_logging.sw
 # ---------------------------------
 
 
@@ -86,8 +89,6 @@ def train(
     val_loader = DataLoader(val_dataset, batch_size=size_of_batch)
     test_loader = DataLoader(test_dataset, batch_size=size_of_batch)
 
-    writer = SummaryWriter()
-
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     logger.info(f"Device: {device.type}")
 
@@ -106,9 +107,6 @@ def train(
                 epoch, train_loss, val_loss
             )
         )
-
-    writer.flush()
-    writer.close()
 
     torch.save(model.state_dict(), save_model_dir)
     logger.info("Saved trained model.")
@@ -160,6 +158,8 @@ def main(
         batch_size,
         magnitude_increase,
     )
+    writer.flush()
+    writer.close()
 
 
 if __name__ == "__main__":

--- a/hab/utils/habs_logging.py
+++ b/hab/utils/habs_logging.py
@@ -1,13 +1,22 @@
-from pathlib import Path
-import logging
-from logging.handlers import RotatingFileHandler
 import sys
+import logging
+from pathlib import Path
 from datetime import datetime
+from logging.handlers import RotatingFileHandler
+from torch.utils.tensorboard import SummaryWriter
 
 now = datetime.now()
 time_suffix = now.strftime("%Y-%m-%d_%H-%M-%S")
+
+# logging
 LOGFILE = f"/content/gdrive/MyDrive/habs_google/logs/logfile_{time_suffix}.log"
 Path(LOGFILE).parent.mkdir(parents=True, exist_ok=True)
 
 ch = logging.StreamHandler(sys.stdout)
 fh = RotatingFileHandler(LOGFILE, maxBytes=2 ** 32, backupCount=1)
+
+# tensorboard
+TENSORBOARD_DIR = "/content/gdrive/MyDrive/habs_google/runs"
+RUN_DIR = str(Path(TENSORBOARD_DIR) / time_suffix)
+
+sw = SummaryWriter(log_dir=RUN_DIR)


### PR DESCRIPTION
This PR adds the code for creating the **tensorboard writer** in `habs_logging.py`. 

I decided to follow the same format that I did for the logging handlers. This means that I pulled out the setup code for the SummaryWriter object (setting the correct directory to write to). I realized the SummaryWriter was a similar process to the logging when I had to use the `datetime` object to help create the name for each SummaryWriter file. Instead of repeating the same datetime code
```
now = datetime.now()
time_suffix = now.strftime("%Y-%m-%d_%H-%M-%S")
```
over again in the Colab Notebook, I thought it would be good idea to try to use the same datetime call for the SummaryWriter directory. That way, the logging file and the SummaryWriter/tensorboard file for each run would correspond exactly because they are using the same exact time stamp. If we used two separate datetime calls in different parts of the program, the time stamps for the two files would be very close, and almost always the same, but it would leave the chance that they could be slightly off from each other. By using the same datetime call in `habs_logging.py`, there is no ambiguity.

This abstraction also makes the code in Colab Notebook or `train.py` easier to read. The summary writer is set up in one line of code `writer = habs_logging.sw`, instead of 5 different lines. 

Similar to with the logging directory in `habs_logging.py` we hardcoded the tensorboard directory to be our **habs_google** directory: `TENSORBOARD_DIR = "/content/gdrive/MyDrive/habs_google/runs"`. In the feature we can pull this out and configure the tensorboard directory, along with the logfile directory, but right now it would just add another parameter to have to pass in and worry about. We already have 10 parameters we are passing in to `train`. Plus since the directories are pulled out into `habs_logging` and aren't called directly in `train.py`, it makes configuring these values more complicated. Long story short, having the root directories hard coded to the Google Drive directory for the logger and summary writer is fine for now. 

Related Issue: #49