### PR TITLE
Feature/update train

### DIFF
--- a/hab/model/blocks/block.py
+++ b/hab/model/blocks/block.py
@@ -50,7 +50,7 @@ class Block(nn.Module):
         if self.downsample is not None:
             identity = self.downsample(x)
 
-        out += identity
+        out += identity  # SKIPPING
         out = self.relu(out)
 
         return out

--- a/hab/train.py
+++ b/hab/train.py
@@ -63,10 +63,13 @@ def train(
     logger.info("Loading data.")
 
     # TODO - experiment with different combinations of transformations
-    data_transform = transforms.Compose(
+    train_val_transform = transforms.Compose(
         [
             CropTimestamp(),
             transforms.RandomCrop((32, 32)),
+            transforms.RandomRotation(90),
+            # transforms.RandomVerticalFlip(0.5),
+            # transforms.RandomHorizontalFlip(0.5),
             transforms.ToTensor(),
             transforms.Normalize(
                 (0.485, 0.456, 0.406), (0.229, 0.224, 0.225)
@@ -74,16 +77,29 @@ def train(
         ]
     )
 
-    # TODO - make separate transform object for test_dataset?
+    test_transform = transforms.Compose(
+        [
+            CropTimestamp(),
+            transforms.Resize((32, 32)),
+            transforms.ToTensor(),
+            transforms.Normalize(
+                (0.485, 0.456, 0.406), (0.229, 0.224, 0.225)
+            ),  # Calculated on ImageNet dataset
+        ]
+    )
+
+    logger.info(f"Train/Val Transforms Applied: {train_val_transform}")
+    logger.info(f"Test Transforms Applied: {test_transform}")
+    logger.info(f"Model Architecture: {model}")
 
     train_dataset = HABsDataset(
-        train_data_dir, data_transform, "train", magnitude_increase
+        train_data_dir, train_val_transform, "train", magnitude_increase
     )
     val_dataset = HABsDataset(
-        val_data_dir, data_transform, "validation", magnitude_increase
+        val_data_dir, train_val_transform, "validation", magnitude_increase
     )
     test_dataset = HABsDataset(
-        test_data_dir, data_transform, "test", magnitude_increase
+        test_data_dir, test_transform, "test", magnitude_increase
     )
 
     train_loader = DataLoader(train_dataset, batch_size=size_of_batch)


### PR DESCRIPTION
This PR updates `train.py` with changes that were made in the Colab notebook, `habs_launchpad.ipynb`. Two main changes were made:

1. Separated out the test transform from the train/val transform. This is because the train/val transform performs transformations that changes the original image such as randomly cropping the image to get it to the desired 32x32 size and randomly rotating it. This is necessary for data augmentation purposes. However, when we are testing the images, we do not want to perform these transformations because we want to test the image directly. Meaning we do not want to change it. We just want to see if it contains HABs or not. Therefore, the only transformation that needs to take place is a normal resize to 32x32. 

2. Included the new log statements that print out the two transform objects and the model. These logs are helpful because they state exactly what transformations that were used in the particular run, in addition to portraying the exact architecture of the model. 