### PR TITLE
Feature/nn

### DIFF
--- a/hab/train.py
+++ b/hab/train.py
@@ -1,7 +1,7 @@
 import logging
 import typer
 import torch
-from torch.nn import Module
+from torch import nn
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 from torchvision import transforms
@@ -34,10 +34,10 @@ def train(
     val_data_dir: str,
     test_data_dir: str,
     save_model_dir: str,
-    model: Module,
+    model: nn.Module,
     epochs: int,
     optimizer: Optimizer,
-    criterion: Module,
+    criterion: nn.Module,
     size_of_batch: int = 1,
     magnitude_increase: int = 1,
 ):


### PR DESCRIPTION
This PR changes the format of the import for PyTorch's Module class. 

Instead of directly importing the Module class at the top like `from torch.nn import Module` we only import `nn` from torch at the top. Then for the typing in the method parameters we call `nn.Module`. 

This changed version is better because it explicitly states where the `Module` class is coming from. Since `Module` is a pretty generic name and used a lot in ML, we want to make it straight forward on what exact class is being used. In the original version, by just stating `Module` for the type, it was not very clear where the module class was coming from. 