### PR TITLE
Feature/log predictions

### DIFF
--- a/hab/train.py
+++ b/hab/train.py
@@ -26,6 +26,8 @@ logger.addHandler(habs_logging.fh)
 
 # -------- tensorboard ------------
 writer = habs_logging.sw
+
+
 # ---------------------------------
 
 
@@ -129,7 +131,9 @@ def train(
     logger.info("Saved trained model.")
 
     logger.info("Testing model.")
-    total, correct = evaluate(model, test_loader)
+    predictions, classifications, total, correct = evaluate(model, test_loader)
+    logger.info(f"Predicted Values: {predictions}")
+    logger.info(f"Classifications: {classifications}")
     logger.info(
         "Accuracy of the network on the 10 test images: %d %%" % (100 * correct / total)
     )

--- a/hab/train.py
+++ b/hab/train.py
@@ -26,8 +26,6 @@ logger.addHandler(habs_logging.fh)
 
 # -------- tensorboard ------------
 writer = habs_logging.sw
-
-
 # ---------------------------------
 
 

--- a/hab/utils/training_helper.py
+++ b/hab/utils/training_helper.py
@@ -1,22 +1,7 @@
-import logging
 import torch
 from torch.nn import Module
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
-
-from hab.utils import habs_logging
-
-# ------------ logging ------------
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s HABs:%(levelname)s - %(name)s - %(message)s"
-)
-
-logging.captureWarnings(True)
-
-logger = logging.getLogger(__name__)
-logger.addHandler(habs_logging.ch)
-logger.addHandler(habs_logging.fh)
-# ---------------------------------
 
 
 def training_lap(
@@ -77,6 +62,8 @@ def evaluate(model: Module, data_loader: DataLoader):
 
     :param model: Model to be evaluated.
     :param data_loader: Data loader that contains the test/validation data.
+    :return predictions: Predicted probabilities for possible classes per image.
+    :return classifications: Classification value for each image.
     :return total: Total number of images tested.
     :return correct: Number of test images that were classified correctly.
     """
@@ -89,8 +76,9 @@ def evaluate(model: Module, data_loader: DataLoader):
             images, targets = batch
 
             outputs = model(images)  # nn.module __call__()
-            _, predicted = torch.max(outputs.data, 1)
+            predictions = outputs.data
+            _, classifications = torch.max(predictions, 1)
             total += targets.size(0)
-            correct += (predicted == targets).sum().item()
+            correct += (classifications == targets).sum().item()
 
-            return total, correct
+            return predictions, classifications, total, correct


### PR DESCRIPTION
This PR includes log statements in `train.py` that print the prediction tensor and the classification tensor. These new log statements allow us to see the actual outputs that the model is predicting, allowing us to make sure that it is not just picking things randomly and different classifications are being selected. For example, not just outputting all 1 (clear) values.

In order to do this, I made `evaluate` in `training_helper.py` return new variables **predictions** and **classifications**, in addition to the original return values of **total** and **correct**. These values are then saved in `train.py` and are then logged. I wanted to continue with the same pattern of not including log statements in `training_helper.py` and keeping the scope of the logging in 'train.py'. We want to limit the amount of changing state in `training_helper.py`, and this way enables us to do this. To go along with this, all of the logging imports and setup was deleted from `training_helper.py`, since it is not needed anymore in this scope. 
