### PR TITLE
Feature/log targets

### DIFF
--- a/hab/train.py
+++ b/hab/train.py
@@ -134,7 +134,7 @@ def train(
     logger.info(f"  Target Values: {targets}")
     logger.info(f"Classifications: {classifications}")
     logger.info(
-        "Accuracy of the network on the 10 test images: %d %%" % (100 * correct / total)
+        "Accuracy of the network on the test images: %d %%" % (100 * correct / total)
     )
 
 

--- a/hab/train.py
+++ b/hab/train.py
@@ -129,8 +129,9 @@ def train(
     logger.info("Saved trained model.")
 
     logger.info("Testing model.")
-    predictions, classifications, total, correct = evaluate(model, test_loader)
+    predictions, classifications, total, correct, targets = evaluate(model, test_loader)
     logger.info(f"Predicted Values: {predictions}")
+    logger.info(f"  Target Values: {targets}")
     logger.info(f"Classifications: {classifications}")
     logger.info(
         "Accuracy of the network on the 10 test images: %d %%" % (100 * correct / total)

--- a/hab/utils/training_helper.py
+++ b/hab/utils/training_helper.py
@@ -69,6 +69,7 @@ def evaluate(
     :return classifications: Classification value for each image.
     :return total: Total number of images tested.
     :return correct: Number of test images that were classified correctly.
+    :return targets: The correct class labels for the images.
     """
     correct = 0
     total = 0
@@ -84,4 +85,4 @@ def evaluate(
             total += targets.size(0)
             correct += (classifications == targets).sum().item()
 
-            return predictions, classifications, total, correct
+            return predictions, classifications, total, correct, targets


### PR DESCRIPTION
This PR adds a log statement that records the target values in `evaluate`. This addition allows us to better understand the results of the predictions that the trained model makes on the test images. 

I also removed the hard-coded value of `10` in the log for the test images. This is because the number of test images changes often. So it is less confusing not to have a hard-coded value, incase I forget to update it. 